### PR TITLE
Move to Scala 2.11 along with the main lib

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ organization in ThisBuild := "com.gu"
 
 releaseSettings
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.4"
 
-crossScalaVersions := Seq("2.10.4")
+crossScalaVersions := Seq("2.11.4")
 
 publishArtifact := false
 

--- a/management-play/build.sbt
+++ b/management-play/build.sbt
@@ -1,8 +1,8 @@
 
 libraryDependencies ++= Seq(
-    "com.gu" %% "management" % "5.33",
-    "com.gu" %% "management-internal" % "5.33",
-    "com.gu" %% "management-logback" % "5.33",
+    "com.gu" %% "management" % "5.35",
+    "com.gu" %% "management-internal" % "5.35",
+    "com.gu" %% "management-logback" % "5.35",
     "org.reflections" % "reflections" % "0.9.8" exclude("javassist", "javassist"), // http://code.google.com/p/reflections/issues/detail?id=140
     "org.specs2" %% "specs2" % "1.13" % "test",
     "com.typesafe.play" %% "play" % "2.3.1",


### PR DESCRIPTION
The main management libs have abandoned 2.10, so I think this can too.
