### PR TITLE
Allow InternalManagementServer to use a fixed port

### DIFF
--- a/management-play/build.sbt
+++ b/management-play/build.sbt
@@ -1,8 +1,8 @@
 
 libraryDependencies ++= Seq(
-    "com.gu" %% "management" % "5.35",
-    "com.gu" %% "management-internal" % "5.35",
-    "com.gu" %% "management-logback" % "5.35",
+    "com.gu" %% "management" % "5.36-SNAPSHOT",
+    "com.gu" %% "management-internal" % "5.36-SNAPSHOT",
+    "com.gu" %% "management-logback" % "5.36-SNAPSHOT",
     "com.typesafe.play" %% "play" % "2.4.6",
     "com.typesafe.play" %% "play-test" % "2.4.6" % "test"
 )


### PR DESCRIPTION
Followup to PR https://github.com/guardian/guardian-management/pull/30

_(needs to be updated to the correct `guardian-management` version number when released)_